### PR TITLE
refactor program/shader/DRY into separate Glsl.Program class

### DIFF
--- a/glsl.js
+++ b/glsl.js
@@ -144,7 +144,17 @@ limitations under the License.
      * @public
      */
     defines: null,
-      
+
+    /** 
+     * Synchronize a variable from the Javascript into the GLSL.
+     * @param {String} name variable name to synchronize.
+     * @param {String} value variable value.
+     * @public
+     */
+    syncVariable: function (name, value) {
+      this.recSyncVariable(name, value, this.uniformTypes[name],  name);
+    },
+
     // ~~~ Going Private Now
 
     parseDefines: function (src) {
@@ -208,10 +218,6 @@ limitations under the License.
       }
     },
 
-    syncVariable: function (name, value) {
-      return this.recSyncVariable(name, value, this.uniformTypes[name],  name);
-    },
-
     recSyncVariable: function (name, value, type, varpath) {
       var gl = this.gl;
       if (!type) {
@@ -227,7 +233,7 @@ limitations under the License.
       var loc = this.locations[varpath];
       if (type in this.structTypes) {
         var structType = this.structTypes[type];
-                if (arrayType) {
+        if (arrayType) {
           for (var i=0; i<arrayLength && i<value.length; ++i) {
             var pref = varpath+"["+i+"].";
             var v = value[i];


### PR DESCRIPTION
Hello,

very nice library and nice idea !
I would like to use it for some 2D image processing but I require a specific vertex shader (for some warping), and sometimes 2 fragment shaders (2 gl programs).
I refactored the glsl.js code to put program / shaders / DRY stuff into a separate Glsl.Program class, so that I can instantiate it directly (instead of Glsl) with a different vertex shader.
Code is otherwise unchanged.
If you think this could be compatible with what you want for glsl.js , here is my work.
